### PR TITLE
Unit-2.3-JS: Minimizing/Expanding Functionality

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -60,3 +60,7 @@ input {
     border-bottom: 1px solid indigo;
     background: transparent;
   }
+  .collapse {
+    display: none;
+  }
+  

--- a/css/style.css
+++ b/css/style.css
@@ -59,8 +59,11 @@ input {
     border: 0;
     border-bottom: 1px solid indigo;
     background: transparent;
-  }
-  .collapse {
+}
+.expand {
+    display: table-row;
+}
+.collapse {
     display: none;
   }
   

--- a/html/user-profile.html
+++ b/html/user-profile.html
@@ -50,10 +50,10 @@
         });
 
         if (buttonText.innerHTML === "Collapse") {
-            buttonText.innerHTML = "Expand";
-          } else if (buttonText.innerHTML === "Expand") {
+          buttonText.innerHTML = "Expand";
+        } else if (buttonText.innerHTML === "Expand") {
             buttonText.innerHTML = "Collapse";
-          };
+        }
       }
 
 //        var target = event.target;

--- a/html/user-profile.html
+++ b/html/user-profile.html
@@ -36,82 +36,48 @@
       </tr>
       <tr>
         <td>
-          <button id="cardToggleButton"  onclick="cardExpandCollapse(this)">Collapse</button>
+          <button onclick="cardExpandCollapse(this)">Collapse</button>
+        </td>
+      </tr>
+    </table>
+    <table> 
+      <tr>
+        <td>ID:</td>
+        <td>#0000</td>
+      </tr>
+      <tr>
+        <td>Name:</td>
+        <td>John Smith</td>
+      </tr>
+      <tr class="expand">
+        <td>Phone:</td>
+        <td>000-576-5309</td>
+      </tr>
+      <tr class="expand">
+        <td>Email:</td>
+        <td>john.smith@banno.com</td>
+      </tr>
+      <tr>
+        <td>
+          <button onclick="cardExpandCollapse(this)">Collapse</button>
         </td>
       </tr>
     </table>
     <script>
       function cardExpandCollapse(element) {
+        const button = element;
         const collapses = element.parentNode.parentNode.parentNode.querySelectorAll(".expand");
-        const buttonText = document.getElementById("cardToggleButton");
 
         collapses.forEach (collapse => {
           collapse.classList.toggle('collapse');
         });
-
-        if (buttonText.innerHTML === "Collapse") {
-          buttonText.innerHTML = "Expand";
-        } else if (buttonText.innerHTML === "Expand") {
-            buttonText.innerHTML = "Collapse";
+        
+        if (button.textContent === "Collapse") {
+          button.textContent = "Expand";
+        } else if (button.textContent === "Expand") {
+          button.textContent = "Collapse";
         }
       }
-
-//        var target = event.target;
-  //      var collapse = document.getElementsByClassName("expand");
-
- //       if collapse == ("expand") {
-//          collapse.target.style.visibility = 'hidden';
-  //      }
-
-    //    collapse(event) {
-  
-  
-
-
-
-
-
-
-
-        // get by id
-        // target children that i want hidden
-        // make sure it's an array
-        // set classes for specific items in array
-        /*
-        const parent = document.getElementById("userCard");
-        const children = parent.children;
-        const moreChildren = children.childElementCount;
-        
-        //const children = parent.children;
-        //const childrenOfChildren = child
-
-       // var collapse = children.filter(getElementsByClassName("expand"));
-        var buttonText = document.getElementById("cardToggleButton");
-      //  console.log(collapse)
-        console.log(parent)
-        console.log(children)
-        console.log(moreChildren)
-        
-        */
-        
-       // if (buttonText.innerHTML == "Collapse") {
-       //   collapse.style.display = "none";
-       //   buttonText.innerHTML = "Expand";
-       // } else {
-       //   collapse.style.display = "table-row";
-       //   buttonText.innerHTML = "Collapse";
-       // }
-        /*
-        for (var i = 0; i < collapse.length; i++) {
-         collapse[i].classList.toggle("collapse");
-        }
-
-        if (buttonText.innerHTML === "Collapse") {
-          buttonText.innerHTML = "Expand";
-        } else {
-          buttonText.innerHTML = "Collapse";
-        }*/
-      
     </script>
   </body>
 </html>

--- a/html/user-profile.html
+++ b/html/user-profile.html
@@ -68,15 +68,9 @@
         const button = element;
         const collapses = element.parentNode.parentNode.parentNode.querySelectorAll(".expand");
 
-        collapses.forEach (collapse => {
-          collapse.classList.toggle('collapse');
-        });
-        
-        if (button.textContent === "Collapse") {
-          button.textContent = "Expand";
-        } else if (button.textContent === "Expand") {
-          button.textContent = "Collapse";
-        }
+        collapses.forEach(dataElement => { dataElement.classList.toggle('collapse'); });
+
+        button.textContent = button.textContent === "Collapse" ? "Expand" : "Collapse";
       }
     </script>
   </body>

--- a/html/user-profile.html
+++ b/html/user-profile.html
@@ -17,7 +17,7 @@
       </nav>
     </header>
     <h3>User Profile</h3>
-    <table id="userCard"> 
+    <table> 
       <tr>
         <td>ID:</td>
         <td>#0000</td>
@@ -42,16 +42,16 @@
     </table>
     <script>
       function cardExpandCollapse(element) {
-        const collapses = element.parentNode.parentNode.parentNode.querySelectorAll('.expand');
-        var buttonText = document.getElementById("cardToggleButton");
+        const collapses = element.parentNode.parentNode.parentNode.querySelectorAll(".expand");
+        const buttonText = document.getElementById("cardToggleButton");
 
         collapses.forEach (collapse => {
           collapse.classList.toggle('collapse');
         });
 
-        if (buttonText.innerHTML == "Collapse") {
+        if (buttonText.innerHTML === "Collapse") {
             buttonText.innerHTML = "Expand";
-          } else if (buttonText.innerHTML == "Expand") {
+          } else if (buttonText.innerHTML === "Expand") {
             buttonText.innerHTML = "Collapse";
           };
       }

--- a/html/user-profile.html
+++ b/html/user-profile.html
@@ -36,17 +36,17 @@
       </tr>
       <tr>
         <td>
-          <button id="bText"  Onclick="openClose()">Collapse</button>
+          <button id="cardToggleButton"  onclick="cardExpandCollapse()">Collapse</button>
         </td>
       </tr>
     </table>
     <script>
-      function openClose() {
+      function cardExpandCollapse() {
         var collapse = document.getElementsByClassName("expand");
-        var buttonText = document.getElementById("bText");
+        var buttonText = document.getElementById("cardToggleButton");
 
         for (var i = 0; i < collapse.length; i++) {
-          collapse[i].classList.toggle("collapse");
+         collapse[i].classList.toggle("collapse");
         }
 
         if (buttonText.innerHTML === "Collapse") {

--- a/html/user-profile.html
+++ b/html/user-profile.html
@@ -5,35 +5,56 @@
     <meta content="text/html; charset=UTF-8">
     <link rel="stylesheet" type="text/css" href="../css/style.css" />
 </head>
-<body>
-  <header>
-    <nav>
-      <ul>
-        <li><a href="user-profile.html">User Profile</a></li>
-        <li><a href="user-list.html">User List</a></li>
-        <li><a href="create-user.html">Create User</a></li>
-        <li><a href="edit-user.html">Edit User</a></li>
-      </ul>
-    </nav>
-  </header>
-  <table> 
-      <h3>User Profile</h3>
-    <tr>
-      <td>ID:</td>
-      <td>#0000</td>
-    </tr>
-    <tr>
-      <td>Name:</td>
-      <td>John Smith</td>
-    </tr>
-    <tr>
-      <td>Phone:</td>
-      <td>000-000-0000</td>
-    </tr>
-    <tr>
-      <td>Email:</td>
-      <td>john.smith@banno.com</td>
-    </tr>
-  </table>
-</body>
+  <body>
+    <header>
+      <nav>
+        <ul>
+          <li><a href="user-profile.html">User Profile</a></li>
+          <li><a href="user-list.html">User List</a></li>
+          <li><a href="create-user.html">Create User</a></li>
+          <li><a href="edit-user.html">Edit User</a></li>
+        </ul>
+      </nav>
+    </header>
+    <h3>User Profile</h3>
+    <table> 
+      <tr>
+        <td>ID:</td>
+        <td>#0000</td>
+      </tr>
+      <tr>
+        <td>Name:</td>
+        <td>John Smith</td>
+      </tr>
+      <tr class="expand">
+        <td>Phone:</td>
+        <td>000-576-5309</td>
+      </tr>
+      <tr class="expand">
+        <td>Email:</td>
+        <td>john.smith@banno.com</td>
+      </tr>
+      <tr>
+        <td>
+          <button id="bText"  Onclick="openClose()">Collapse</button>
+        </td>
+      </tr>
+    </table>
+    <script>
+      function openClose() {
+        var collapse = document.getElementsByClassName("expand");
+        var buttonText = document.getElementById("bText");
+
+        for (var i = 0; i < collapse.length; i++) {
+          collapse[i].classList.toggle("collapse");
+        }
+
+        if (buttonText.innerHTML === "Collapse") {
+          buttonText.innerHTML = "Expand";
+        } else {
+          buttonText.innerHTML = "Collapse";
+        }
+      }
+    </script>
+  </body>
 </html>

--- a/html/user-profile.html
+++ b/html/user-profile.html
@@ -17,7 +17,7 @@
       </nav>
     </header>
     <h3>User Profile</h3>
-    <table> 
+    <table id="userCard"> 
       <tr>
         <td>ID:</td>
         <td>#0000</td>
@@ -36,25 +36,19 @@
       </tr>
       <tr>
         <td>
-          <button id="cardToggleButton"  onclick="cardExpandCollapse()">Collapse</button>
+          <button id="cardToggleButton"  onclick="cardExpandCollapse(this)">Collapse</button>
         </td>
       </tr>
     </table>
     <script>
-      function cardExpandCollapse() {
-        var collapse = document.getElementsByClassName("expand");
-        var buttonText = document.getElementById("cardToggleButton");
+      function cardExpandCollapse(element) {
+        const collapses = element.parentNode.parentNode.parentNode.querySelectorAll('.expand');
 
-        for (var i = 0; i < collapse.length; i++) {
-         collapse[i].classList.toggle("collapse");
-        }
-
-        if (buttonText.innerHTML === "Collapse") {
-          buttonText.innerHTML = "Expand";
-        } else {
-          buttonText.innerHTML = "Collapse";
-        }
+        collapses.forEach (collapse => {
+          collapse.classList.toggle('collapse');
+        });
       }
+
     </script>
   </body>
 </html>

--- a/html/user-profile.html
+++ b/html/user-profile.html
@@ -43,12 +43,75 @@
     <script>
       function cardExpandCollapse(element) {
         const collapses = element.parentNode.parentNode.parentNode.querySelectorAll('.expand');
+        var buttonText = document.getElementById("cardToggleButton");
 
         collapses.forEach (collapse => {
           collapse.classList.toggle('collapse');
         });
+
+        if (buttonText.innerHTML == "Collapse") {
+            buttonText.innerHTML = "Expand";
+          } else if (buttonText.innerHTML == "Expand") {
+            buttonText.innerHTML = "Collapse";
+          };
       }
 
+//        var target = event.target;
+  //      var collapse = document.getElementsByClassName("expand");
+
+ //       if collapse == ("expand") {
+//          collapse.target.style.visibility = 'hidden';
+  //      }
+
+    //    collapse(event) {
+  
+  
+
+
+
+
+
+
+
+        // get by id
+        // target children that i want hidden
+        // make sure it's an array
+        // set classes for specific items in array
+        /*
+        const parent = document.getElementById("userCard");
+        const children = parent.children;
+        const moreChildren = children.childElementCount;
+        
+        //const children = parent.children;
+        //const childrenOfChildren = child
+
+       // var collapse = children.filter(getElementsByClassName("expand"));
+        var buttonText = document.getElementById("cardToggleButton");
+      //  console.log(collapse)
+        console.log(parent)
+        console.log(children)
+        console.log(moreChildren)
+        
+        */
+        
+       // if (buttonText.innerHTML == "Collapse") {
+       //   collapse.style.display = "none";
+       //   buttonText.innerHTML = "Expand";
+       // } else {
+       //   collapse.style.display = "table-row";
+       //   buttonText.innerHTML = "Collapse";
+       // }
+        /*
+        for (var i = 0; i < collapse.length; i++) {
+         collapse[i].classList.toggle("collapse");
+        }
+
+        if (buttonText.innerHTML === "Collapse") {
+          buttonText.innerHTML = "Expand";
+        } else {
+          buttonText.innerHTML = "Collapse";
+        }*/
+      
     </script>
   </body>
 </html>


### PR DESCRIPTION
## The Purpose
- Gain a basic understanding of javascript
- Apply simple vanilla javascript to project to give if more functionality
- Use javascript to change the layout of the project in a meaningful, UX-improving way

## What It Does

- This feature adds an OpenClose() function to allow the content to be toggled between classes `expand` and `collapse`(the collapse class being styled as `display: hidden;`) giving it a way of expanding and collapsing certain content in the user profile card.

- OpenClose() also changes the button text every time it's clicked by using the `.innerHTML` method.

#### This accomplishes the following requirements given for  [Unit 2.3](https://github.com/phillnab/nathan-phillips-ux-iop/blob/unit-2.3-js/issues/unit-2/2.3-javascript.md) :

### 1. Expanding:
- [x] Clicking a button will expand the user profile
- [x] The button is styled in a way that says "hey, I'll expand the profile if you click me"

### 2. Minimizing:
- [x] Clicking a button will minimize the user profile
- [x] The button is styled in a way that says "hey, le'me make this profile a little smaller"

### 3. Expand/Minimize:
- [x]  If minimized, clicking the button will expand the user profile
- [x] If expanded, clicking the button will minimize the user profile
- [x] Have expanding and minimizing functionality run by the same button

### The changes to look for are:
1. After `Expand` button clicked <b>Phone and Email</b> are added below in their own rows
2. After `Collapse` button clicked <b>only ID and Name</b> appear in their own rows
3. Button text shows `Collapse` when all four rows are showing <b>Not</b> when only two rows are showing
4. Button text shows `Expand` when top two rows are showing <b>Not</b> when all four rows are showing

# How To Test
- Clone Repo [nathan-phillips-ux-iop](https://github.com/phillnab/nathan-phillips-ux-iop)
- Checkout branch `nathan-phillips-ux-iop/unit-2.3-js`
- Open <b>only</b> `user-profile.html` and `style.css` to view locally
- Compare your expanded and collapsed views to the following screenshots

## Expanded

1. Showing ID, Name, Phone, and Email data rows
2. Button text displays `Collapse`

<img width="575" alt="screen shot 2019-02-28 at 11 54 02 am" src="https://user-images.githubusercontent.com/29068248/53587278-92088d80-3b4f-11e9-95c5-788b399547b7.png">


## Collapsed

1. Only showing ID and Name data rows
2. Button text displays `Expand`

![screen shot 2019-02-28 at 10 44 06 am](https://user-images.githubusercontent.com/29068248/53587761-d6485d80-3b50-11e9-87a1-fc39403c6ad1.png)


## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [ ] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [x] Updated the docs, if necessary
- [x] Included the appropriate labels
- [x] Referenced applicable issues ()

Browsers tested:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer


