### PR TITLE
Unit 4.1 Edit User Component

### DIFF
--- a/src/components/edit-user.html
+++ b/src/components/edit-user.html
@@ -98,7 +98,6 @@
       }
 
       editUserProfile(event) {
-        // event.preventDefault();
         this.editSelected = !this.editSelected;
       }
 

--- a/src/components/edit-user.html
+++ b/src/components/edit-user.html
@@ -1,35 +1,31 @@
 <link rel="import" href="~@banno/polymer/polymer-element.html">
 <link rel="import" href="~@banno/polymer/lib/elements/dom-if.html">
+<link rel="import" href="./user-profile.html">
 
 <dom-module id="edit-user">
   <template>
     <style>
-      fieldset {
+      table {
         box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
         background: #eef1f4;
-        border: none;
         border-radius: 3px;
+        padding: 30px;
         margin-top: 10px;
-        width: 375px;
-      }
-      fieldset div {
-        text-align: left;
-        margin-top: 15px;
+        width: 400px;
       }
       button {
         background-color: DarkSlateBlue;
         color: #fcfcff;
         border-radius: 3px;
         text-align: center;
-        padding: 10px;
+        padding: 12px;
         margin-top: 20px;
+        font-size: 12px;
       }
-      label {
-        font-size: 18px;
+       label {
         margin-top: 25px;
-        padding-left: 30px;
         padding-right: 5px;
-      }
+      } 
       input {
         font-size: 18px;
         border: 0;
@@ -39,27 +35,50 @@
     </style>
     <h3>Edit User Component</h3>
     <template is="dom-if" if="[[editSelected]]">
-      <form>
-        <fieldset>
-          <div>
-            <label for="firstName">First name:</label>
-            <input type="text" name="firstName" id="firstName">
-          </div>
-          <div>
-            <label for="lastName">Last name:</label>
-            <input type="text" name="lastName" id="lastName">
-          </div>
-          <div>
-            <label for="phone">Phone:</label>
-            <input type="text" name="phone" id="phone">
-          </div>
-          <div>
-            <label for="email">Email:</label>
-            <input type="text" name="email" id="email">
-          </div>
-          <button type="submit" on-click="editUserProfile">[[editButtonText(editSelected)]]</button>
-        </fieldset>
-      </form>
+      <table>
+        <tr>
+          <td>ID :</td>
+          <td>[[user.id]]</td>
+        </tr>
+        <tr>
+          <td><label for="name">Name :</label></td>
+          <td>[[user.firstName]] [[user.lastName]]</td>
+        </tr>
+        <tr>
+          <td><label for="phone">Phone :</label></td>
+          <td>[[user.phoneNumber]]</td>
+        </tr>
+        <tr>
+          <td><label for="email">Email :</label></td>
+          <td>[[user.email]]</td>
+        </tr>
+        <tr>
+          <td><button type="button" on-click="editUserProfile">[[editButtonText(editSelected)]]</button></td>
+        </tr>
+      </table>
+    </template>
+    <template is="dom-if" if="[[!editSelected]]">
+      <table>
+        <tr>
+          <td><label for="firstName">First name :</label></td>
+          <td><input type="text" name="firstName" id="firstName" value="{{user.firstName}}" on-input="updateFirstName"></td>
+        </tr>
+        <tr>
+          <td><label for="lastName">Last name :</label></td>
+          <td><input type="text" name="lastName" id="lastName" value="{{user.lastName}}" on-input="updateLastName"></td>
+        </tr>
+        <tr>
+          <td><label for="phone">Phone :</label></td>
+          <td><input type="text" name="phone" id="phone" value="{{user.phoneNumber}}" on-input="updatePhoneNumber"></td>
+        </tr>
+        <tr>
+          <td><label for="email">Email :</label></td>
+          <td><input type="text" name="email" id="email" value="{{user.email}}" on-input="updateEmail"></td>
+        </tr>
+        <tr>
+          <td><button type="button" on-click="editUserProfile">[[editButtonText(editSelected)]]</button></td>
+        </tr>
+      </table>
     </template>
   </template>
   <script type="module">
@@ -71,16 +90,36 @@
           editSelected: {
             type: Boolean,
             value: true
+          },
+          user: {
+            type: Object,
           }
         };
       }
 
       editUserProfile(event) {
+        // event.preventDefault();
         this.editSelected = !this.editSelected;
       }
 
       editButtonText(editSelected) {
         return editSelected ? `Edit` : `Save`;
+      }
+
+      updateFirstName(event) {
+        this.set('user.firstName', event.target.value);
+      }
+
+      updateLastName(event) {
+        this.set('user.lastName', event.target.value);
+      }
+
+      updatePhoneNumber(event) {
+        this.set('user.phoneNumber', event.target.value);
+      }
+
+      updateEmail(event) {
+        this.set('user.email', event.target.value);
       }
     }
     customElements.define(EditUser.is, EditUser);

--- a/src/components/edit-user.html
+++ b/src/components/edit-user.html
@@ -1,4 +1,5 @@
 <link rel="import" href="~@banno/polymer/polymer-element.html">
+<link rel="import" href="~@banno/polymer/lib/elements/dom-if.html">
 
 <dom-module id="edit-user">
   <template>
@@ -37,31 +38,50 @@
       }
     </style>
     <h3>Edit User Component</h3>
-    <form>
-      <fieldset>
-        <div>
-          <label for="firstName">First name:</label>
-          <input type="text" name="firstName" id="firstName">
-        </div>
-        <div>
-          <label for="lastName">Last name:</label>
-          <input type="text" name="lastName" id="lastName">
-        </div>
-        <div>
-          <label for="phone">Phone:</label>
-          <input type="text" name="phone" id="phone">
-        </div>
-        <div>
-          <label for="email">Email:</label>
-          <input type="text" name="email" id="email">
-        </div>
-        <button type="submit">Save Edit</button>
-      </fieldset>
-    </form>
+    <template is="dom-if" if="[[editSelected]]">
+      <form>
+        <fieldset>
+          <div>
+            <label for="firstName">First name:</label>
+            <input type="text" name="firstName" id="firstName">
+          </div>
+          <div>
+            <label for="lastName">Last name:</label>
+            <input type="text" name="lastName" id="lastName">
+          </div>
+          <div>
+            <label for="phone">Phone:</label>
+            <input type="text" name="phone" id="phone">
+          </div>
+          <div>
+            <label for="email">Email:</label>
+            <input type="text" name="email" id="email">
+          </div>
+          <button type="submit" on-click="editUserProfile">[[editButtonText(editSelected)]]</button>
+        </fieldset>
+      </form>
+    </template>
   </template>
   <script type="module">
     class EditUser extends Polymer.Element {
       static get is() { return 'edit-user'; }
+
+      static get properties() {
+        return {
+          editSelected: {
+            type: Boolean,
+            value: true
+          }
+        };
+      }
+
+      editUserProfile(event) {
+        this.editSelected = !this.editSelected;
+      }
+
+      editButtonText(editSelected) {
+        return editSelected ? `Edit` : `Save`;
+      }
     }
     customElements.define(EditUser.is, EditUser);
     export default EditUser;

--- a/src/components/intern-app.html
+++ b/src/components/intern-app.html
@@ -1,5 +1,6 @@
 <link rel="import" href="~@banno/polymer/polymer-element.html">
 <link rel="import" href="./user-list.html">
+<link rel="import" href="./edit-user.html">
 
 <dom-module id="intern-app">
   <template>
@@ -17,6 +18,7 @@
     <header>
       <h1>Intern App</h1>
     </header>
+    <edit-user></edit-user>
     <user-list user-profiles="[[userProfiles]]"></user-list>
   </template>
   <script type="module">

--- a/src/components/intern-app.html
+++ b/src/components/intern-app.html
@@ -11,14 +11,11 @@
         padding: 14px 25px;
         margin: 0px;
       }
-      h1:hover {
-        background-color: DarkSlateBlue;
-      }
     </style>
     <header>
       <h1>Intern App</h1>
     </header>
-    <edit-user></edit-user>
+    <edit-user user="[[userProfiles.0]]"></edit-user>
     <user-list user-profiles="[[userProfiles]]"></user-list>
   </template>
   <script type="module">

--- a/src/components/user-list.html
+++ b/src/components/user-list.html
@@ -7,11 +7,11 @@
     </style>
     <h3>User List Component</h3>
     <template is="dom-repeat" items="[[userProfiles]]">
-      <user-profile 
-        id="[[item.id]]" 
-        first-name="[[item.firstName]]" 
+      <user-profile
+        id="[[item.id]]"
+        first-name="[[item.firstName]]"
         last-name="[[item.lastName]]"
-        phone-number="[[item.phoneNumber]]" 
+        phone-number="[[item.phoneNumber]]"
         email="[[item.email]]">
       </user-profile>
     </template>


### PR DESCRIPTION
## The Purpose
- To learn how to work with nested components and binding data with Polymer
- To generate a working edit user button to use in further testing throughout the build of this project

## What It Does
1. This imports `edit-user` into `intern-app` to be displayed as a single editable user profile that defaults to the first row in the created `userProfiles` array inside `intern-app` .

2. The properties inside the `userProfiles` array are binded to the `edit-user` component by assigning `userProfiles.0` to the created `user` object inside `edit-user` itself.

3. Inside `edit-user` the properties that were bound then can be used to display properties like so: 

`[[user.firstName]]`

4. Within `edit-user` a new function was created called `editUserProfile()` to allow a switch between templates through a Boolean property called `editSelected` that defaults as `true`.  This is triggered by an `on-click` event when the <b>Edit/Save</b> button is selected to know whether to show the input form or not through the setup of a`dom-if` in the two templates.

5. Additionally inside the input form template a two way bound value property and an on-click event were added to each input tag to keep track of the current value it holds. 

#### Example: 
- `value="{{user.firstName}}" on-input="updateFirstName"` 

6. A new function is created for each input `on-click` event to set the current value to it's new target value

## This accomplishes the following requirements given for  [Unit 4.1](https://github.com/phillnab/nathan-phillips-ux-iop/blob/master/issues/unit-4/4.1-polymer-components.md)
- The following HTML pages are represented in the Polymer app:
    - [x] user-list.html
    - [x] user-profile.html
    - [x] create-user.html
    - [x] edit-user.html
- [x] The `user-list` element has `user-profile` components nested inside it
- [x] The `user-profile` component maintains its expand and collapse functionality

# How To Test
- Clone Repo [nathan-phillips-ux-iop](https://github.com/phillnab/nathan-phillips-ux-iop)
- Checkout branch `nathan-phillips-ux-iop/unit-4.1-edit-user`
- Run `yarn`
- Run `yarn build`
- Run `yarn start`

### Step 1 
- See if it matches this:

![Screen Shot 2019-05-15 at 2 32 22 PM](https://user-images.githubusercontent.com/29068248/57803783-d3f0ab00-771e-11e9-8c2b-9552f7553fa7.png)

### Step 2 
- Click `Edit` and change default data and `Save`:

![Screen Shot 2019-05-15 at 2 33 05 PM](https://user-images.githubusercontent.com/29068248/57803697-a0ae1c00-771e-11e9-842f-60de23f42b00.png)

### Step 3 
- See if it Saved the input:

![Screen Shot 2019-05-15 at 2 33 14 PM](https://user-images.githubusercontent.com/29068248/57803687-9e4bc200-771e-11e9-8ddb-443df16487f4.png)

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [x] Updated the docs, if necessary
- [x] Included the appropriate labels
- [x] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)

Browsers tested:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer

